### PR TITLE
fix: avoid fetching the master branch for conform if already on master

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Fetch master branch for reference
         run: git fetch origin master:master
+        if: github.ref_name != 'master'
       - name: Install siderolabs/conform
         run: go install github.com/siderolabs/conform/cmd/conform@latest
       - name: Run siderolabs/conform


### PR DESCRIPTION
Running the `conform` job fails on master:

```
fatal: Refusing to fetch into current branch refs/heads/master of non-bare repository
```