### PR TITLE
feat: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space
+max_line_length = 120
+
+[*.py]
+indent_style = space
+max_line_length = 100


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) helps in programmatically enforcing the code style between different users and their IDEs.