### PR TITLE
chore: update SOPS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [`bootstrap.py`](bootstrap.py) script automates the end-to-end setup of a Ta
 ./bootstrap.py clusters/<cluster>.yaml
 ```
 
-and monitoring the progress. The `bootstrap.py` script requires the `talosctl`, `helm` and `flux` binaries to be present in `$PATH`. First it will use `talosctl` to generate a configuration for the cluster and to patch the nodes, then it will apply the [Cilium](https://cilium.io/) CNI networking layer using `helm`, and finally it will use `flux` to install [Flux](https://fluxcd.io/) and point it to the upstream defined in the cluster configuration.
+and monitoring the progress. The `bootstrap.py` script requires the `talosctl`, `helm` and `flux` binaries to be present in `$PATH`. First it will use `talosctl` to generate a configuration for the cluster and to patch the nodes, then it will apply the [Cilium](https://cilium.io/) CNI networking layer using `helm`, and finally it will use `flux` to install [Flux](https://fluxcd.io/) and point it to the upstream defined in the cluster configuration. If a SOPS GPG key is supplied in the cluster configuration, `kubectl` is used to create the SOPS secret in the `flux-system` namespace before installing Flux.
 
 ## Secrets
 

--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -2,7 +2,7 @@ cluster:
   name: example # The name of the cluster. The domain is appended to this to form a FQDN.
   domain: home # The network domain that the cluster resides in. This is used for all nodes.
   secrets: secrets/example/secrets.yaml # Cluster secrets file. Generate one with `talosctl gen secrets`.
-  #sops: secrets/example/sops.asc # Private key for Mozilla SOPS (https://github.com/mozilla/sops)
+  #sops: secrets/example/sops.asc # Private key for Mozilla SOPS (https://github.com/mozilla/sops) (optional)
   flux: # Configuration for Flux (GitOps)
     url: ssh://git@server.home/example/flux # The source repository and path for Flux to track
     branch: master # The branch in the repository for Flux to track


### PR DESCRIPTION
Updates README to mention SOPS and marks the SOPS parameter as optional in the example cluster configuration.