### PR TITLE
fix: run CI for PRs from forks as well

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,8 +1,6 @@
 on:
-  push:
-    branches:
-      - master
   pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
Filtering using `master` apparently disables CI runs for PRs from forks that target `twelho:master`.