### PR TITLE
fix: report name of binary correctly in command util

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -76,7 +76,7 @@ def with_domain(*parts):
 def command(name):
     binary = shutil.which(name)
     if not binary:
-        raise Exception(f"{binary} not found in PATH or not executable")
+        raise Exception(f"{name} not found in PATH or not executable")
     return lambda *a: [
         print("==>", " ".join([binary, *a])),
         subprocess.run([binary, *a]),


### PR DESCRIPTION
The exception is raised if the binary is falsy, e.g. None when it is missing, but it is also used in the exception message, leading to an unhelpful error message "None not found in PATH or not executable".
This change fixes the issue, reporting the missing binary properly.