### PR TITLE
feat: add support for using the cluster record as the endpoint

### DIFF
--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -1,6 +1,6 @@
 cluster:
   name: my-cluster # The name of the cluster. The domain is appended to this to form a FQDN.
-  domain: example.com # The network domain that the cluster resides in. This is used for all nodes.
+  domain: example.com # The network domain that the cluster resides in, used for all nodes (optional)
   secrets: secrets/my-cluster/secrets.yaml # Cluster secrets file. Generate one with `talosctl gen secrets`.
   sops: my-cluster.example.com # GPG ID/fingerprint of Mozilla SOPS key (https://github.com/mozilla/sops) (optional)
   flux: # Configuration for Flux (GitOps) (optional)
@@ -23,7 +23,10 @@ cluster:
   manifests: manifests/my-cluster
 
 controlplane:
-  record: my-cluster-control-plane # The control plane DNS record. The domain is appended to this to form a FQDN.
+  record: my-cluster-control-plane # The control plane IP or DNS record. The domain is appended to this to form a FQDN.
+  # Use the record above as the Talos API endpoint instead of the control plane node addresses, for remote clusters.
+  # Do NOT use with Talos VIP, see https://www.talos.dev/latest/introduction/prodnotes/#load-balancing-the-talos-api
+  record-as-endpoint: false # (optional)
   patches: # Patches to apply to all control plane nodes (optional)
     - "@patch/example.yaml"
   nodes: # Addresses of the control plane nodes. DNS names are recommended, but static IPs should work as well.


### PR DESCRIPTION
This way it's possible to bootstrap remote clusters, where the control plane node addresses can't directly be used as the endpoint. Also fixes support for using IPs instead of DNS names, including making the domain field optional.