### PR TITLE
fix: make bootstrapping with `rotate-server-certificates` work

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -513,9 +513,6 @@ def main():
         *[e for o in cilium_opts for e in ("--set", o)],
     )
 
-    # Wait for the cluster to be healthy
-    talosctl("health")
-
     # Add Mozilla SOPS key
     if "sops" in config["cluster"] and not check_resource(
         "secret/sops-gpg", namespace="flux-system"
@@ -593,6 +590,9 @@ def main():
         # Apply CRDs before everything else
         kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(crds))
         kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(manifests))
+
+    # Wait for the cluster to be healthy
+    talosctl("health")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With `machine.kubelet.extraArgs.rotate-server-certificates == true`, Talos will produce [TLS errors](https://www.talos.dev/v1.7/introduction/troubleshooting/#talos-complains-about-certificate-errors-on-kubelet-api) until a CSR approving controller, such as the [Kubelet Serving Certificate Approver](https://github.com/alex1989hu/kubelet-serving-cert-approver), has been deployed in the cluster. Notably, this causes `talosctl health` to fail, but resources can still be deployed by, e.g., Flux. Since the pattern here is to deploy the CSR approver to fix the situation, we need to move the `talosctl health` check after Flux has been installed and configured (potentially through the direct-apply manifests). This allows an empty cluster with `rotate-server-certificates` to bootstrap properly.