### PR TITLE
fix: restart Cilium operator and agent pods on Gateway API installation

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -593,6 +593,18 @@ def main():
         if len(manifests):
             kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(manifests))
 
+    # Gateway API flakiness: restart the Cilium operator and agents to pick up existing gateways,
+    # see https://docs.cilium.io/en/latest/network/servicemesh/gateway-api/gateway-api/#installation
+    if config["cluster"]["cilium"].get("gateway-api", {}).get("enabled"):
+        kubectl(
+            "--namespace",
+            "kube-system",
+            "rollout",
+            "restart",
+            "deployment/cilium-operator",
+            "daemonset/cilium",
+        )
+
     # Wait for the cluster to be healthy
     talosctl("health")
 


### PR DESCRIPTION
This is instructed by the [Cilium installation docs](https://docs.cilium.io/en/latest/network/servicemesh/gateway-api/gateway-api/#installation), and is needed for Cilium to pick up existing Gateway resources referring to its GatewayClass.