### PR TITLE
fix: skip apply if no manifests were generated

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -588,8 +588,10 @@ def main():
                 manifests.append(manifest)
 
         # Apply CRDs before everything else
-        kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(crds))
-        kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(manifests))
+        if len(crds):
+            kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(crds))
+        if len(manifests):
+            kubectl("apply", "-f", "-", stdin=yaml.safe_dump_all(manifests))
 
     # Wait for the cluster to be healthy
     talosctl("health")


### PR DESCRIPTION
Small fix for https://github.com/twelho/talos-bootstrap/pull/27: in case Kustomize produces no CRDs or other manifests, we need to skip `kubectl apply` to avoid it complaining.