### PR TITLE
fix: update excluded types for Flannel and kube-proxy

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -366,6 +366,8 @@ def main():
         "componentstatuses",
         "validatingadmissionpolicies.admissionregistration.k8s.io",
         "validatingadmissionpolicybindings.admissionregistration.k8s.io",
+        "nodes.metrics.k8s.io",
+        "pods.metrics.k8s.io",
     }
 
     # Discover non-namespaced and namespaced resource types from the API server


### PR DESCRIPTION
This avoids permission errors in clusters with metrics collection when cleaning up Flannel and kube-proxy resources.