### PR TITLE
feat: enable eBPF-based masquerading and host routing

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -414,6 +414,8 @@ def main():
     cilium_opts = [
         "ipam.mode=kubernetes",
         "kubeProxyReplacement=true",
+        "bpf.masquerade=true",  # eBPF-based masquerading
+        # "bpf.datapathMode=netkit",  # netkit device mode, requires kernel 6.8 (not yet in Talos)
         "securityContext.capabilities.ciliumAgent={CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,"
         "SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}",
         "securityContext.capabilities.cleanCiliumState={NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}",


### PR DESCRIPTION
This is a prerequisite for many of Cilium's [advanced tuning options](https://docs.cilium.io/en/stable/operations/performance/tuning/#ebpf-host-routing), and should also improve performance in general without sacrificing compatibility. The netkit device mode requires Linux 6.8, which Talos does not yet have, but I've added the option here for the future.