### PR TITLE
feat: support enabling Cilium native routing

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -48,6 +48,11 @@ config_schema = Schema(
                     Optional("host-network"): bool,
                     Optional("privileged-ports"): bool,
                 },
+                Optional("native-routing"): {
+                    "enabled": bool,
+                    "ipv4-cidr": str_schema,
+                    "direct-routes": bool,
+                },
                 Optional("bgp"): {
                     "enabled": bool,
                 },
@@ -485,6 +490,14 @@ def main():
         cilium_opts += [
             "policyAuditMode=true",  # Audit mode, do not block traffic
         ]
+
+    if native_routing := config["cluster"]["cilium"].get("native-routing"):
+        if native_routing["enabled"]:
+            cilium_opts += [
+                "routingMode=native",  # Enable native routing
+                f"ipv4NativeRoutingCIDR={native_routing["ipv4-cidr"]}",
+                f"autoDirectNodeRoutes={'true' if native_routing["direct-routes"] else 'false'}",
+            ]
 
     if bgp := config["cluster"]["cilium"].get("bgp"):
         if bgp["enabled"]:

--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -22,6 +22,10 @@ cluster:
       # (in the style of NodePort) without requiring a LoadBalancer service (optional)
       host-network: false
       privileged-ports: false # Allow Envoy to bind to ports <1024 when using Gateway API (optional)
+    native-routing: # Configure native routing support (optional)
+      enabled: true # Enable Cilium native routing datapath
+      ipv4-cidr: 10.244.0.0/16 # IPv4 CIDR used for native routing
+      direct-routes: true # Enable if you have L2 connectivity between all nodes
     bgp: # Configure Cilium BGP Control Plane support (optional)
       enabled: true # Enable Cilium BGP Control Plane
   sops: my-cluster.example.com # GPG ID/fingerprint of Mozilla SOPS key (https://github.com/mozilla/sops) (optional)


### PR DESCRIPTION
Talos uses 10.244.0.0/16 as the [default Pod CIDR](https://www.talos.dev/v1.9/introduction/troubleshooting/#conflict-on-kubernetes-and-host-subnets), which is why it's in the example configuration.