### PR TITLE
feat: update Gateway API configuration with ALPN support

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -510,7 +510,11 @@ def main():
     envoy_caps = ["NET_ADMIN", "PERFMON", "BPF"]
     if gw_api := config["cluster"]["cilium"].get("gateway-api"):
         if gw_api["enabled"]:
-            cilium_opts += ["gatewayAPI.enabled=true"]
+            cilium_opts += [
+                "gatewayAPI.enabled=true",  # Enable Gateway API support
+                "gatewayAPI.enableAlpn=true",  # GRPCRoutes with TLS require ALPN for HTTP/2
+                "gatewayAPI.enableAppProtocol=true",  # GEP-1911: Backend Protocol Selection
+            ]
             if gw_api.get("host-network"):
                 cilium_opts += ["gatewayAPI.hostNetwork.enabled=true"]
             if gw_api.get("privileged-ports"):


### PR DESCRIPTION
This is already recommended in the [Talos documentation](https://www.talos.dev/v1.9/kubernetes-guides/network/deploying-cilium/#without-kube-proxy), allows for TLS-enabled GRPCRoutes with Cilium's Gateway API support.