### PR TITLE
feat: allow configuring Flux path if using SSH

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -84,6 +84,7 @@ config_schema = Schema(
                     "url": str_schema,
                     "branch": str_schema,
                     "key": file_schema,
+                    Optional("path"): str_schema,
                 },
             },
             Optional("image"): str_schema,
@@ -766,13 +767,19 @@ def main():
         flux_opts = []
         if "ssh" in config["cluster"]["flux"]:
             # SSH configuration given, bootstrap flux
+            custom_path = config["cluster"]["flux"]["ssh"].get("path", False)
+
             flux_opts += [
                 "bootstrap",
                 "git",
-                f"--url={config['cluster']['flux']['url']}",
-                f"--branch={config['cluster']['flux']['branch']}",
-                f"--path=clusters/{config['cluster']['name']}",
-                f"--private-key-file={config['cluster']['flux']['key']}",
+                f"--url={config['cluster']['flux']['ssh']['url']}",
+                f"--branch={config['cluster']['flux']['ssh']['branch']}",
+                f"--private-key-file={config['cluster']['flux']['ssh']['key']}",
+                f"--path={
+                    f'{config['cluster']['flux']['ssh']['path']}'
+                    if custom_path
+                    else f'clusters/{config['cluster']['name']}'
+                }",
             ]
         else:
             # No SSH configuration given, just perform a Flux install

--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -52,6 +52,8 @@ cluster:
       branch: master # The branch in the repository for Flux to track
       # Flux SSH key file for accessing the configuration repo. Generate with `ssh-keygen`.
       key: secrets/my-cluster/flux.key
+      # Custom path for flux; default is `clusters/{cluster name}` (optional)
+      path: clusters/my-cluster/flux
   # Specify a customized installation image, for example, from https://factory.talos.dev/ (optional).
   # Applied to all nodes. If no tag is given, the CLI version is used, enabling automatic upgrades.
   image: factory.talos.dev/installer-secureboot/376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba


### PR DESCRIPTION
This allows deviating from the original default.
This also fixes the SSH bootstrapping logic, which was broken years ago
and never fixed.