### PR TITLE
feat: add better support for Cilium metrics

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -40,10 +40,20 @@ config_schema = Schema(
             Optional("domain"): str_schema,
             "secrets": file_schema,
             Optional("cilium"): {
-                Optional("metrics"): bool,
+                Optional("metrics"): {
+                    "enabled": bool,
+                    "servicemonitor": bool,
+                },
                 Optional("hubble"): {
                     "enabled": bool,
-                    Optional("metrics"): bool,
+                    Optional("metrics"): {
+                        "enabled": bool,
+                        "servicemonitor": bool,
+                    },
+                    Optional("export"): {
+                        "enabled": bool,
+                        "path": str_schema,
+                    },
                 },
                 Optional("hardening"): {
                     "enabled": bool,
@@ -640,11 +650,20 @@ def main():
     ):
         cilium_opts += ["operator.replicas=1"]
 
-    if config["cluster"]["cilium"].get("metrics"):
+    if metrics := config["cluster"]["cilium"].get("metrics"):
+        enabled = "true" if metrics["enabled"] else "false"
         cilium_opts += [
-            "prometheus.enabled=true",  # cilium-agent metrics
-            "operator.prometheus.enabled=true",  # cilium-operator metrics
+            f"prometheus.enabled={enabled}",  # cilium-agent metrics
+            f"operator.prometheus.enabled={enabled}",  # cilium-operator metrics
         ]
+        if metrics["enabled"]:
+            servicemonitor = "true" if metrics["servicemonitor"] else "false"
+            cilium_opts += [
+                f"hubble.metrics.serviceMonitor.enabled={servicemonitor}",
+                f"prometheus.serviceMonitor.enabled={servicemonitor}",
+                f"envoy.prometheus.serviceMonitor.enabled={servicemonitor}",
+                f"operator.prometheus.serviceMonitor.enabled={servicemonitor}",
+            ]
 
     if hubble := config["cluster"]["cilium"].get("hubble"):
         enabled = "true" if hubble["enabled"] else "false"
@@ -653,14 +672,23 @@ def main():
             f"hubble.ui.enabled={enabled}",  # Enable Hubble UI
             f"hubble.relay.enabled={enabled}",  # Enable Hubble Relay
         ]
-        if hubble["enabled"] and hubble.get("metrics"):
-            # Hubble metrics
+        if metrics := hubble.get("metrics"):
+            servicemonitor = "true" if metrics["servicemonitor"] else "false"
+            if metrics["enabled"]:
+                cilium_opts += [
+                    "hubble.metrics.enableOpenMetrics=true",
+                    "hubble.metrics.enabled={"
+                    "dns,drop,flow,flows-to-world,icmp,port-distribution,tcp,"
+                    "httpV2:exemplars=true;labelsContext=source_ip\\,source_namespace\\,"
+                    "source_workload\\,destination_ip\\,destination_namespace\\,"
+                    "destination_workload\\,traffic_direction}",
+                    f"hubble.metrics.serviceMonitor.enabled={servicemonitor}",
+                ]
+        if export := hubble.get("export"):
+            enabled = "true" if export["enabled"] else "false"
             cilium_opts += [
-                "hubble.metrics.enableOpenMetrics=true",
-                "hubble.metrics.enabled={dns,drop,tcp,flow,port-distribution,icmp,"
-                "httpV2:exemplars=true;labelsContext=source_ip\\,source_namespace\\,"
-                "source_workload\\,destination_ip\\,destination_namespace\\,"
-                "destination_workload\\,traffic_direction}",
+                f"hubble.export.static.enabled={enabled}",
+                f"hubble.export.static.filePath={export['path']}",
             ]
 
     enable_hardening = True

--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -3,10 +3,17 @@ cluster:
   domain: example.com # The network domain that the cluster resides in, used for all nodes (optional)
   secrets: secrets/my-cluster/secrets.yaml # Cluster secrets file. Generate one with `talosctl gen secrets`.
   cilium: # Specify additional configuration for the Cilium installation (optional)
-    metrics: false # Enable cilium-agent and cilium-operator metrics (optional)
+    metrics: # Configure Cilium metrics (optional)
+      enabled: false # Enable Cilium metrics
+      servicemonitor: false # Enable creating ServiceMonitor resources. Requires CRDs to be installed via manifests-pre.
     hubble: # Configure Cilium Hubble (optional)
       enabled: false # Enable Hubble with Hubble UI
-      metrics: false # Enable Hubble metrics collection (optional)
+      metrics: # Configure Hubble metrics (optional)
+        enabled: false # Enable Hubble metrics
+        servicemonitor: false # Enable creating ServiceMonitor resources. Requires CRDs to be installed via manifests-pre.
+      export: # Configure event export (optional)
+        enabled: false # Enable exporting Hubble events
+        path: /var/run/cilium/hubble/events.log # Path to write Hubble events to
     hardening: # Hardening options for Cilium (optional)
       enabled: true # Harden the Cilium installation: all permitted traffic must have a matching NetworkPolicy
       # Start in audit mode: NetworkPolicy violations (including lack of policies) will be logged instead of denied


### PR DESCRIPTION
This expands the existing metrics options to also allow for configuring whether to enable the ServiceMonitor resources, and updates the Hubble metrics to include everything except for `kafka`. Additionally allows enabling Hubble's event log export.

These aren't optimal for more advanced setups, especially for the event exporter; normally you would configure filters which events you want to export, instead of logging every single packet. In the future we can either expose more options in talos-bootstrap, or allow enabling the dynamic exporter instead of the static one.