### PR TITLE
feat: add control for Cilium IPv6 support

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -72,6 +72,9 @@ config_schema = Schema(
                 Optional("node-ipam"): {
                     "enabled": bool,
                 },
+                Optional("ipv6"): {
+                    "enabled": bool,
+                },
                 Optional("netkit"): bool,
                 Optional("bgp"): {
                     "enabled": bool,
@@ -764,6 +767,12 @@ def main():
         if node_ipam["enabled"]:
             cilium_opts += [
                 "nodeIPAM.enabled=true",  # Use node IPs for LoadBalancer services
+            ]
+
+    if ipv6 := config["cluster"]["cilium"].get("ipv6"):
+        if ipv6["enabled"]:
+            cilium_opts += [
+                "ipv6.enabled=true",  # Enable IPv6 support in Cilium (independent from Kubernetes)
             ]
 
     if gw_api := config["cluster"]["cilium"].get("gateway-api"):

--- a/clusters/example.yaml
+++ b/clusters/example.yaml
@@ -36,6 +36,8 @@ cluster:
       enabled: true # Enable Cilium native routing datapath
       ipv4-cidr: 10.244.0.0/16 # IPv4 CIDR used for native routing
       direct-routes: true # Enable if you have L2 connectivity between all nodes
+    ipv6: # IPv6 configuration, independent from Kubernetes (optional)
+      enabled: true # Enable IPv6 support in Cilium
     # Enable Cilium netkit device mode instead of veth (optional)
     # WARNING: REQUIRES kernel 6.8 or newer (Talos v1.9), cluster WILL BECOME INACCESSIBLE if enabled on older kernels!
     # For details, see https://docs.cilium.io/en/latest/operations/performance/tuning/#netkit-device-mode


### PR DESCRIPTION
This control is independent from Kubernetes IPAM.